### PR TITLE
修复了应为不是 /data/xxx.json 请求地址导致 arms interceptor 报错的情况 

### DIFF
--- a/packages/xconsole-service/src/interceptors/armsResponseInterceptor/index.ts
+++ b/packages/xconsole-service/src/interceptors/armsResponseInterceptor/index.ts
@@ -28,7 +28,11 @@ function armsResponseInterceptor(response) {
   // API
   const { url, data: dataStr } = config
   const requestData = new URLSearchParams(dataStr)
-  const [targetUrl, targetApiType] = /\/data\/(.+)\.json/.exec(url)
+  const matches = /\/data\/(.+)\.json/.exec(url)
+  if (!matches) {
+    return response
+  }
+  const [targetUrl, targetApiType] = matches
   let api = targetUrl
   if (targetApiType.indexOf('multi') !== -1) {
     try {


### PR DESCRIPTION
fix #4, 修复了应为不是 /data/xxx.json 请求地址导致 arms interceptor 报错的情况 